### PR TITLE
Fix processing dashes between numbers

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -815,8 +815,8 @@ function processLine(line: string) {
 					// Double dash → em dash
 					mainLine += '—';
 					i++; // Skip the second dash
-				} else if (i > 0 && line[i - 1].match(/[a-zA-Z]/) && nextChar.match(/[a-zA-Z]/)) {
-					// Dash between letters → add backslash
+				} else if (i > 0 && line[i - 1].match(/[a-zA-Z0-9]/) && nextChar.match(/[a-zA-Z0-9]/)) {
+					// Dash between letters/numbers → add backslash
 					mainLine += '-\\';
 				} else {
 					// Single dash → em dash
@@ -857,7 +857,7 @@ function processLine(line: string) {
 						} else if (nextChar === '-') {
 							processed += '—';
 							i++; // Skip the second dash
-						} else if (i > 0 && part[i - 1].match(/[a-zA-Z]/) && nextChar.match(/[a-zA-Z]/)) {
+						} else if (i > 0 && part[i - 1].match(/[a-zA-Z0-9]/) && nextChar.match(/[a-zA-Z0-9]/)) {
 							processed += '-\\';
 						} else {
 							processed += '—';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hyphens between letters or numbers are now preserved by escaping them, preventing unintended conversion to em dashes (e.g., in alphanumeric tokens like IDs, codes, or version strings).
  * Applies consistently within parenthetical background-vocals text as well.
  * Existing em-dash behavior for spaced dashes and double dashes remains unchanged.
  * Improves text rendering accuracy without altering any public interfaces or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->