### PR TITLE
temporarily disable ASR.verify redirects during 26h1 move

### DIFF
--- a/src/initial/onload.ts
+++ b/src/initial/onload.ts
@@ -4,6 +4,9 @@ import { isFromInterface } from "../wdelivery/main";
 const asrHost = import.meta.env.VITE_ASR_HOST ?? "https://interface.spicylyrics.org";
 
 async function onloadMain() {
+  // Temporarily disabled ASR.verify redirects during 26h1 move
+  onFinish();
+  return;
   if (!isFromInterface && !import.meta.env.DEV) {
     const params = new URLSearchParams(window.location.search);
     const appSceneRedirectToken = params.get("asr");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ASR verification redirects have been disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->